### PR TITLE
Fix: Standardize Public Key Format for Compatibility

### DIFF
--- a/src/curve.js
+++ b/src/curve.js
@@ -12,6 +12,12 @@ const PRIVATE_KEY_DER_PREFIX = Buffer.from([
     48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 110, 4, 34, 4, 32
 ]);
 
+const KEY_BUNDLE_TYPE = Buffer.from([5]);
+
+const prefixKeyInPublicKey = function (pubKey) {
+  return Buffer.concat([KEY_BUNDLE_TYPE, pubKey]);
+};
+
 function validatePrivKey(privKey) {
     if (privKey === undefined) {
         throw new Error("Undefined private key");
@@ -40,7 +46,7 @@ function scrubPubKeyFormat(pubKey) {
 }
 
 exports.generateKeyPair = function() {
-    if(typeof nodeCrypto.generateKeyPairSync === 'function') {
+    try {
         const {publicKey: publicDerBytes, privateKey: privateDerBytes} = nodeCrypto.generateKeyPairSync(
             'x25519',
             {
@@ -48,22 +54,19 @@ exports.generateKeyPair = function() {
                 privateKeyEncoding: { format: 'der', type: 'pkcs8' }
             }
         );
-        // 33 bytes
-        // first byte = 5 (version byte)
-        const pubKey = publicDerBytes.slice(PUBLIC_KEY_DER_PREFIX.length-1, PUBLIC_KEY_DER_PREFIX.length + 32);
-        pubKey[0] = 5;
+        const pubKey = publicDerBytes.slice(PUBLIC_KEY_DER_PREFIX.length, PUBLIC_KEY_DER_PREFIX.length + 32);
     
         const privKey = privateDerBytes.slice(PRIVATE_KEY_DER_PREFIX.length, PRIVATE_KEY_DER_PREFIX.length + 32);
     
         return {
-            pubKey,
+            pubKey: prefixKeyInPublicKey(pubKey),
             privKey
         };
-    } else {
+    } catch(e) {
         const keyPair = curveJs.generateKeyPair(nodeCrypto.randomBytes(32));
         return {
             privKey: Buffer.from(keyPair.private),
-            pubKey: Buffer.from(keyPair.public),
+            pubKey: prefixKeyInPublicKey(Buffer.from(keyPair.public)),
         };
     }
 };


### PR DESCRIPTION
Prefixes generated X25519 public keys with a key bundle type identifier.

This ensures consistency with the expected format across different components and systems, preventing potential compatibility issues.

This solves problem when running Baileys in Bun